### PR TITLE
Remove unnecessary DEPENDS system_lib

### DIFF
--- a/xarm_api/CMakeLists.txt
+++ b/xarm_api/CMakeLists.txt
@@ -111,7 +111,6 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES xarm_api
   CATKIN_DEPENDS roscpp std_msgs
-  DEPENDS system_lib
 )
 
 ###########


### PR DESCRIPTION
That line threw an error when I compiled using `catkin_make`. Looking up the error, it looks like that line is unnecessary: https://answers.ros.org/question/288967/build-package-with-system_lib-not-found/?answer=288971#post-id-288971

I then recompiled without that line, and didn't see any adverse effects (though I'm still dealing with the same other issues I was before, so not a perfect test)