### PR TITLE
fixing prefixing for limited and effort_control

### DIFF
--- a/xarm_description/urdf/xarm7_robot_macro.xacro
+++ b/xarm_description/urdf/xarm7_robot_macro.xacro
@@ -25,7 +25,7 @@
       <origin xyz="${xyz}" rpy="${rpy}" />
     </joint>
 
-    <xacro:if value="$(arg limited)">
+    <xacro:if value="${limited}">
       <xacro:xarm7_urdf prefix="${prefix}"
         joint1_lower_limit="${-pi*0.99}" joint1_upper_limit="${pi*0.99}"
         joint2_lower_limit="${-2.18}" joint2_upper_limit="${2.18}"
@@ -35,14 +35,14 @@
         joint6_lower_limit="${-1.75}" joint6_upper_limit="${pi*0.99}"
         joint7_lower_limit="${-pi*0.99}" joint7_upper_limit="${pi*0.99}"/>
     </xacro:if>
-    <xacro:unless value="$(arg limited)">
+    <xacro:unless value="${limited}">
       <xacro:xarm7_urdf prefix="${prefix}"/>
     </xacro:unless>
 
-    <xacro:if value="$(arg effort_control)">
+    <xacro:if value="${effort_control}">
       <xacro:xarm7_transmission prefix="${prefix}" hard_interface="EffortJointInterface" />
     </xacro:if>
-    <xacro:unless value="$(arg effort_control)">
+    <xacro:unless value="${effort_control}">
       <xacro:xarm7_transmission prefix="${prefix}" hard_interface="PositionJointInterface" />
     </xacro:unless>
 


### PR DESCRIPTION
this is basically a follow-up to #7 
there were more cases of incorrect prefixing than address in #7. the fix only concerns xarm7 as the analogous files for xarm5 and xarm6 are already ok.