### PR TITLE
xarm_controller: don't try to link to targets in another package

### DIFF
--- a/xarm_controller/CMakeLists.txt
+++ b/xarm_controller/CMakeLists.txt
@@ -138,8 +138,8 @@ include_directories(
 add_library(xarm_hw
   src/xarm_hw.cpp
 )
-add_dependencies(xarm_hw xarm_ros_client ${catkin_EXPORTED_TARGETS})
-target_link_libraries(xarm_hw xarm_ros_client)
+add_dependencies(xarm_hw ${catkin_EXPORTED_TARGETS})
+target_link_libraries(xarm_hw ${catkin_LIBRARIES})
 
 
 add_library(xarm_combined_hw


### PR DESCRIPTION
I got linking errors in `xarm_controller`, which tries to link to `xarm_ros_client`. This is a library built in package `xarm_ros` and we should use `${catkin_LIBRARIES}` to link to it.

Using `catkin_make` the old way can work, but with the more modern `catkin_make_isolated` and `catkin_tools` targets cannot be referenced across packages.