### PR TITLE
add exec_depend ros_controllers

### DIFF
--- a/xarm_planner/package.xml
+++ b/xarm_planner/package.xml
@@ -31,4 +31,5 @@
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>ros_controllers</exec_depend>
 </package>


### PR DESCRIPTION
avoid some error when using moveit config and planner.