### PR TITLE
Minor fix

### DIFF
--- a/xarm_gripper/launch/gripper_rviz_display.launch
+++ b/xarm_gripper/launch/gripper_rviz_display.launch
@@ -18,7 +18,7 @@
   <node
     name="robot_state_publisher"
     pkg="robot_state_publisher"
-    type="state_publisher" />
+    type="robot_state_publisher" />
   <node
     name="rviz"
     pkg="rviz"


### PR DESCRIPTION
Renamed node type `state_publisher` (non existant) to the correct `robot_state_publisher`.