### PR TITLE
Fix catkin make isolated and colcon (fixes #70)

### DIFF
--- a/dual_xarm6_moveit_config/CMakeLists.txt
+++ b/dual_xarm6_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(dual_xarm6_moveit_config)
 
 find_package(catkin REQUIRED)

--- a/xarm_api/CMakeLists.txt
+++ b/xarm_api/CMakeLists.txt
@@ -34,7 +34,6 @@ catkin_package(
 ###########
 include_directories(
   include
-  ${xarm_cxx_sdk_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )
 
@@ -43,7 +42,7 @@ add_library(xarm_ros_client
 )
 
 # Make sure xarm_msgs header files are generated before building xarm_ros_client
-add_dependencies(xarm_ros_client xarm_msgs_generate_messages_cpp xarm_cxx_sdk)
+# add_dependencies(xarm_ros_client xarm_msgs_generate_messages_cpp xarm_cxx_sdk)
 
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context
@@ -53,7 +52,7 @@ add_executable(xarm_driver_node
   src/xarm_driver.cpp
   # src/xarm_driver_callback.cpp
 )
-add_dependencies(xarm_driver_node xarm_msgs_generate_messages_cpp xarm_cxx_sdk)
+# add_dependencies(xarm_driver_node xarm_msgs_generate_messages_cpp xarm_cxx_sdk)
 
 add_executable(example1_report_norm_node 
   test/example1_report_norm.cc 
@@ -97,22 +96,18 @@ add_executable(test_xarm_states
 ## Specify libraries to link a library or executable target against
 
 target_link_libraries(xarm_ros_client 
-  xarm_cxx_sdk
   ${catkin_LIBRARIES}
 )
 
 target_link_libraries(example1_report_norm_node 
-  xarm_cxx_sdk
   ${catkin_LIBRARIES}
 )
 
 target_link_libraries(xarm_driver_node 
-  xarm_cxx_sdk
   ${catkin_LIBRARIES}
 )
 
 target_link_libraries(move_test 
-  xarm_cxx_sdk
   ${catkin_LIBRARIES}
 )
 
@@ -122,7 +117,6 @@ target_link_libraries(test_tool_modbus
 )
 
 target_link_libraries(servo_cart_test 
-  xarm_cxx_sdk
   ${catkin_LIBRARIES}
 )
 
@@ -137,7 +131,6 @@ target_link_libraries(test_xarm_velo_move
 )
 
 target_link_libraries(test_xarm_states 
-  xarm_cxx_sdk
   ${catkin_LIBRARIES}
 )
 
@@ -149,16 +142,16 @@ target_link_libraries(test_xarm_states
 # )
 
 # ## Mark executables and/or libraries for installation
-# install(TARGETS xarm_api
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-#  )
+install(TARGETS xarm_ros_client xarm_driver_node example1_report_norm_node move_test test_tool_modbus servo_cart_test test_xarm_ros_client test_xarm_velo_move test_xarm_states
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 # ## Mark cpp header files for installation
-# install(DIRECTORY include/
-#   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
+install(DIRECTORY include/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
 

--- a/xarm_api/CMakeLists.txt
+++ b/xarm_api/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(xarm_api)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/xarm_api/CMakeLists.txt
+++ b/xarm_api/CMakeLists.txt
@@ -150,7 +150,7 @@ install(TARGETS xarm_ros_client xarm_driver_node example1_report_norm_node move_
 
 # ## Mark cpp header files for installation
 install(DIRECTORY include/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/..
   FILES_MATCHING PATTERN "*.h"
   PATTERN ".svn" EXCLUDE
 )

--- a/xarm_bringup/CMakeLists.txt
+++ b/xarm_bringup/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(xarm_bringup)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
@@ -182,6 +182,8 @@ include_directories(
 #   # myfile2
 #   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 # )
+
+install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 #############
 ## Testing ##

--- a/xarm_controller/CMakeLists.txt
+++ b/xarm_controller/CMakeLists.txt
@@ -199,7 +199,7 @@ install(TARGETS xarm_hw xarm_combined_hw
 
 ## Mark cpp header files for installation
 install(DIRECTORY include/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/..
   FILES_MATCHING PATTERN "*.h"
   PATTERN ".svn" EXCLUDE
  )

--- a/xarm_controller/CMakeLists.txt
+++ b/xarm_controller/CMakeLists.txt
@@ -195,7 +195,7 @@ install(TARGETS xarm_hw xarm_combined_hw
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
- )
+)
 
 ## Mark cpp header files for installation
 install(DIRECTORY include/
@@ -203,6 +203,8 @@ install(DIRECTORY include/
   FILES_MATCHING PATTERN "*.h"
   PATTERN ".svn" EXCLUDE
  )
+
+install(DIRECTORY launch config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(FILES xarm_hw_plugin.xml
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
@@ -236,3 +238,9 @@ target_link_libraries(xarm_traj_controller xarm_hw ${catkin_LIBRARIES})
 
 add_executable(xarm_combined_traj_controller src/xarm_combined_control_node.cpp)
 target_link_libraries(xarm_combined_traj_controller xarm_combined_hw ${catkin_LIBRARIES})
+
+install(TARGETS sample_motion xarm_traj_controller xarm_combined_traj_controller
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)

--- a/xarm_controller/CMakeLists.txt
+++ b/xarm_controller/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(xarm_controller)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
@@ -199,10 +199,14 @@ install(TARGETS xarm_hw xarm_combined_hw
 
 ## Mark cpp header files for installation
 install(DIRECTORY include/
-  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h"
   PATTERN ".svn" EXCLUDE
  )
+
+install(FILES xarm_hw_plugin.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
 # install(FILES

--- a/xarm_description/CMakeLists.txt
+++ b/xarm_description/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(xarm_description)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
@@ -180,7 +180,9 @@ include_directories(
 #   # myfile2
 #   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 # )
-
+install(DIRECTORY launch meshes urdf
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 #############
 ## Testing ##
 #############

--- a/xarm_device/CMakeLists.txt
+++ b/xarm_device/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(xarm_device)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/xarm_gazebo/CMakeLists.txt
+++ b/xarm_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(xarm_gazebo)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
@@ -180,6 +180,10 @@ include_directories(
 #   # myfile2
 #   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 # )
+
+install(DIRECTORY launch worlds
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
 
 #############
 ## Testing ##

--- a/xarm_gripper/CMakeLists.txt
+++ b/xarm_gripper/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(xarm_gripper)
 

--- a/xarm_msgs/CMakeLists.txt
+++ b/xarm_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(xarm_msgs)
 
 ## Compile as C++11, supported in ROS Kinetic and newer

--- a/xarm_planner/CMakeLists.txt
+++ b/xarm_planner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(xarm_planner)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
@@ -223,3 +223,11 @@ target_link_libraries(xarm_simple_planner_test ${catkin_LIBRARIES})
 add_executable(xarm_gripper_planner src/xarm_gripper_planner.cpp)
 add_dependencies(xarm_gripper_planner ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(xarm_gripper_planner ${catkin_LIBRARIES})
+
+install(TARGETS xarm_simple_planner xarm_gripper_planner xarm_simple_planner_test
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/xarm_sdk/CMakeLists.txt
+++ b/xarm_sdk/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(xarm_sdk)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
@@ -78,7 +78,7 @@ add_library(xarm_cxx_sdk
   ${CXX_SDK_SRC_SERIAL}/impl/list_ports/list_ports_win.cc
 )
 
-add_dependencies(xarm_cxx_sdk ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+#dd_dependencies(xarm_cxx_sdk ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 if(MSVC)
   target_link_libraries(xarm_cxx_sdk 
@@ -86,3 +86,17 @@ if(MSVC)
     ${catkin_LIBRARIES}
   )
 endif()
+
+install(TARGETS xarm_cxx_sdk
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+# this is a bit non-standard, but doing otherwise would require changes to the external cxx sdk - TODO: later
+install(DIRECTORY ${CXX_SDK_INC}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/..
+  FILES_MATCHING PATTERN "*.h"
+  PATTERN ".svn" EXCLUDE
+)
+


### PR DESCRIPTION
This should fix building the package with `catkin_make_isolated` and with additional install commands it should allow it to be used with `colcon` as well.