### PR TITLE
add run_depend moveit_simple_controller_manager

### DIFF
--- a/dual_xarm6_moveit_config/package.xml
+++ b/dual_xarm6_moveit_config/package.xml
@@ -18,6 +18,7 @@
 
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>

--- a/examples/xarm5_vacuum_gripper_moveit_config/package.xml
+++ b/examples/xarm5_vacuum_gripper_moveit_config/package.xml
@@ -18,6 +18,7 @@
 
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>

--- a/examples/xarm7_vacuum_gripper_moveit_config/package.xml
+++ b/examples/xarm7_vacuum_gripper_moveit_config/package.xml
@@ -18,6 +18,7 @@
 
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>

--- a/lite6_moveit_config/package.xml
+++ b/lite6_moveit_config/package.xml
@@ -18,6 +18,7 @@
 
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>

--- a/xarm5_gripper_moveit_config/package.xml
+++ b/xarm5_gripper_moveit_config/package.xml
@@ -18,6 +18,7 @@
 
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>

--- a/xarm5_moveit_config/package.xml
+++ b/xarm5_moveit_config/package.xml
@@ -18,6 +18,7 @@
 
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>

--- a/xarm6_gripper_moveit_config/package.xml
+++ b/xarm6_gripper_moveit_config/package.xml
@@ -18,6 +18,7 @@
 
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>

--- a/xarm6_moveit_config/package.xml
+++ b/xarm6_moveit_config/package.xml
@@ -18,6 +18,7 @@
 
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>

--- a/xarm7_gripper_moveit_config/package.xml
+++ b/xarm7_gripper_moveit_config/package.xml
@@ -18,6 +18,7 @@
 
   <run_depend>moveit_ros_move_group</run_depend>
   <run_depend>moveit_fake_controller_manager</run_depend>
+  <run_depend>moveit_simple_controller_manager</run_depend>
   <run_depend>moveit_kinematics</run_depend>
   <run_depend>moveit_planners_ompl</run_depend>
   <run_depend>moveit_ros_visualization</run_depend>

--- a/xarm_planner/package.xml
+++ b/xarm_planner/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>pluginlib</exec_depend>
   <exec_depend>moveit_core</exec_depend>
   <exec_depend>moveit_fake_controller_manager</exec_depend>
+  <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>moveit_ros_planning_interface</exec_depend>
   <exec_depend>moveit_ros_perception</exec_depend>
   <exec_depend>interactive_markers</exec_depend>


### PR DESCRIPTION
The following issues that occur when using gazebo have been fixed

[FATAL] [1669958256.276036133, 8.765000000]: Exception while loading controller manager 'moveit_simple_controller_manager/MoveItSimpleControllerManager': According to the loaded plugin descriptions the class moveit_simple_controller_manager/MoveItSimpleControllerManager with base class type moveit_controller_manager::MoveItControllerManager does not exist. Declared types are  moveit_fake_controller_manager/MoveItFakeControllerManager