### PR TITLE
Fix dependencies for xarm_moveit_servo

### DIFF
--- a/xarm_moveit_servo/CMakeLists.txt
+++ b/xarm_moveit_servo/CMakeLists.txt
@@ -10,7 +10,9 @@ project(xarm_moveit_servo)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   sensor_msgs
-  std_msgs
+  geometry_msgs
+  control_msgs
+  moveit_servo
 )
 
 ## System dependencies are found with CMake's conventions

--- a/xarm_moveit_servo/package.xml
+++ b/xarm_moveit_servo/package.xml
@@ -49,19 +49,15 @@
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>joy</exec_depend>
-  <exec_depend>moveit_servo</exec_depend>
-  <exec_depend>moveit_ros_planning</exec_depend>
 
+  <depend>roscpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>control_msgs</depend>
+  <depend>moveit_servo</depend>
+
+  <exec_depend>joy</exec_depend>
+  <exec_depend>moveit_ros_planning</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
The nodes in the xarm_moveit_servo package require moveit_servo, geometry_msgs and control_msgs for being built. I also removed the std_msgs dependency, which does not seem to be used, and simplified the dependency tags in package.xml.