### PR TITLE
feat: add support for controlling non-xarm hw interfaces in xarm_combined_hw

### DIFF
--- a/xarm_controller/src/xarm_combined_hw.cpp
+++ b/xarm_controller/src/xarm_combined_hw.cpp
@@ -15,7 +15,7 @@ namespace xarm_control
     for (robot_hw = robot_hw_list_.begin(); robot_hw != robot_hw_list_.end(); ++robot_hw)
     {
       xarm_control::XArmHW* xarm_hw_ptr = dynamic_cast<xarm_control::XArmHW *>((*robot_hw).get());
-      if(xarm_hw_ptr->need_reset())
+      if(xarm_hw_ptr && xarm_hw_ptr->need_reset())
         return true;
     }
     return false;
@@ -28,7 +28,7 @@ namespace xarm_control
       for (robot_hw = robot_hw_list_.begin(); robot_hw != robot_hw_list_.end(); ++robot_hw)
       {
         xarm_control::XArmHW* xarm_hw_ptr = dynamic_cast<xarm_control::XArmHW *>((*robot_hw).get());
-        if(!xarm_hw_ptr->wait_fbk_start(timeout))
+        if(xarm_hw_ptr && !xarm_hw_ptr->wait_fbk_start(timeout))
           return false;
       }
     return true;


### PR DESCRIPTION
Hi everyone,

I’m not sure whether this is something you’d want to include in the repository (and I’m also not certain how common the issue we encountered is), but I wanted to share our experience.

**Context**

Our team has a control model that publishes commands using a `std_msgs/Float64MultiArray`. When integrating the model with a Lite6, we ran into an issue: the model also controls additional hardware (simpler than the arm itself), and we wanted to manage everything through a single controller  -- specifically a `position_controllers/JointGroupPositionController`.

Our plan was to use the [xarm_combined_traj_controller](https://github.com/xArm-Developer/xarm_ros/blob/master/xarm_controller/src/xarm_combined_control_node.cpp) node by passing the configuration for both hardware interfaces through the `robot_hardware` parameter.

**Issue**

We encountered segmentation faults, which we traced to the lines highlighted in this PR. The root cause appears to be that our second RobotHW instance does not implement the `need_reset` or `wait_fbk_start` methods.

As a workaround, we vendored the relevant code for both the XArmCombinedHW class and the associated node. However, we thought this might be a useful feature to include in the stable branch.